### PR TITLE
Always render aria-expanded on treeitems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # ivy-tree Changelog
 
+* Always render `aria-expanded` properties on treeitem nodes. This is a not-so-ideal solution for avoiding the Ember deprecation warnings for assigning a property multiple times in a single render loop (see Ember's `[deprecation id: ember-views.render-double-modify]`).
+
 ## 0.1.1 (August 11, 2016)
 
 * Pressing the down arrow when there is no selected treeitem now selects the first one, if any.

--- a/addon/components/ivy-tree-treeitem.js
+++ b/addon/components/ivy-tree-treeitem.js
@@ -15,8 +15,8 @@ export default Component.extend(TreeNodeMixin, {
 
   activeClass: 'active',
 
-  ariaExpanded: computed('isExpanded', 'treeNodeHasChildren', function() {
-    return this.get('treeNodeHasChildren') ? this.get('isExpanded') + '' : null;
+  ariaExpanded: computed('isExpanded', function() {
+    return this.get('isExpanded') + '';
   }).readOnly(),
 
   ariaHidden: computed('treeNodeParent.isExpanded', 'tree', function() {
@@ -50,7 +50,7 @@ export default Component.extend(TreeNodeMixin, {
   },
 
   collapse() {
-    if (!this.get('isExpanded')) {
+    if (!this.get('isExpanded') || !this.get('treeNodeHasChildren')) {
       return;
     }
 
@@ -66,7 +66,7 @@ export default Component.extend(TreeNodeMixin, {
   },
 
   expand() {
-    if (this.get('isExpanded')) {
+    if (this.get('isExpanded') || !this.get('treeNodeHasChildren')) {
       return;
     }
 

--- a/tests/acceptance/aria-attributes-test.js
+++ b/tests/acceptance/aria-attributes-test.js
@@ -65,10 +65,10 @@ test('expanded parent nodes are [aria-expanded="true"]', function(assert) {
   });
 });
 
-test('leaf nodes do have have an aria-expanded attribute', function(assert) {
+test('leaf nodes are [aria-expanded="false"]', function(assert) {
   visit('/');
 
   andThen(() => {
-    assert.notOk(findWithAssert('[role="treeitem"][aria-level="2"]:contains("Oranges")').is('[aria-expanded]'));
+    assert.equal(findWithAssert('[role="treeitem"][aria-level="2"]:contains("Oranges")').attr('aria-expanded'), 'false');
   });
 });

--- a/tests/integration/components/ivy-tree-test.js
+++ b/tests/integration/components/ivy-tree-test.js
@@ -40,7 +40,11 @@ test('it sends an "onToggle" action when a treeitem is expanded', function(asser
   });
   this.render(hbs`
     {{#ivy-tree as |tree|}}
-      {{tree.treeitem onToggle=(action "onToggle")}}
+      {{#tree.treeitem onToggle=(action "onToggle") as |treeitem|}}
+        {{#treeitem.group as |group|}}
+          {{group.treeitem}}
+        {{/treeitem.group}}
+      {{/tree.treeitem}}
     {{/ivy-tree}}
   `);
 


### PR DESCRIPTION
This avoids the Ember deprecation (`[deprecation id: ember-views.render-double-modify]`) for assigning a property multiple times during a single render loop.

This is a non-ideal solution because in order to avoid the double render error either we need to:

1. Make the `aria-expanded` property creation asynchronous to push it into a future run loop after child treeitems may have been created, or
2. Re-architect the library to be given a "tree" of data at the start and it structures itself in its entirety.

The first option makes testing difficult and introduces race conditions where data/properties/attributes haven't settled. The second would require a new major release and therefore this architecture would be unusable in the future, at least this fix allows the library to continue to be used without errors.